### PR TITLE
[LB-385] 회원 정보 수정에 따라 이벤트 발행을 할 수 있다

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'com.lgcms'
-version = '0.3'
+version = '0.4'
 
 java {
 	toolchain {
@@ -33,6 +33,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.springframework.kafka:spring-kafka'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/lgcms/member/common/kafka/config/KafkaConfig.java
+++ b/src/main/java/com/lgcms/member/common/kafka/config/KafkaConfig.java
@@ -1,0 +1,78 @@
+package com.lgcms.member.common.kafka.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.lgcms.member.common.kafka.util.serializer.JsonKafkaDeserializer;
+import com.lgcms.member.common.kafka.util.serializer.JsonKafkaSerializer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.*;
+import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+@EnableKafka
+public class KafkaConfig {
+    @Value("${spring.kafka.bootstrap-servers}")
+    private String bootstrapServer;
+    @Value("${spring.kafka.consumer.group-id}")
+    private String groupId;
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper()
+                .registerModule(new JavaTimeModule());
+    }
+
+    @Bean
+    public ProducerFactory<String, Object> producerFactory() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServer);
+        config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonKafkaSerializer.class);
+        return new DefaultKafkaProducerFactory<>(config);
+    }
+
+    @Bean
+    public KafkaTemplate<String, Object> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
+    }
+
+    private Map<String, Object> commonConsumerProps() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServer);
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        props.put(ConsumerConfig.GROUP_ID_CONFIG,groupId);
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
+        props.put(ErrorHandlingDeserializer.KEY_DESERIALIZER_CLASS, StringDeserializer.class);
+        props.put(ErrorHandlingDeserializer.VALUE_DESERIALIZER_CLASS, JsonDeserializer.class);
+        props.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
+        return props;
+    }
+
+    public <T> ConsumerFactory<String, T> consumerFactory(Class<T> valueType) {
+        Map<String, Object> props = new HashMap<>(commonConsumerProps());
+        return new DefaultKafkaConsumerFactory<>(
+                props,
+                new StringDeserializer(),
+                new JsonKafkaDeserializer(valueType)
+        );
+    }
+
+    public <T> ConcurrentKafkaListenerContainerFactory<String, T> kafkaListenerContainerFactory(Class<T> valueType) {
+        ConcurrentKafkaListenerContainerFactory<String, T> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory(valueType));
+        return factory;
+    }
+}

--- a/src/main/java/com/lgcms/member/common/kafka/config/KafkaListenerConfig.java
+++ b/src/main/java/com/lgcms/member/common/kafka/config/KafkaListenerConfig.java
@@ -1,0 +1,21 @@
+package com.lgcms.member.common.kafka.config;
+
+import com.lgcms.member.common.kafka.dto.KafkaEvent;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+
+@Configuration
+public class KafkaListenerConfig {
+
+    private final KafkaConfig kafkaConfig;
+
+    public KafkaListenerConfig(KafkaConfig kafkaConfig) {
+        this.kafkaConfig = kafkaConfig;
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, KafkaEvent> defaultFactory() {
+        return kafkaConfig.kafkaListenerContainerFactory(KafkaEvent.class);
+    }
+}

--- a/src/main/java/com/lgcms/member/common/kafka/dto/KafkaEvent.java
+++ b/src/main/java/com/lgcms/member/common/kafka/dto/KafkaEvent.java
@@ -1,0 +1,18 @@
+package com.lgcms.member.common.kafka.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class KafkaEvent<T> {
+
+    private String eventId;
+    private String eventType;
+    private String eventTime;
+    private T data;
+}

--- a/src/main/java/com/lgcms/member/common/kafka/util/KafkaEventFactory.java
+++ b/src/main/java/com/lgcms/member/common/kafka/util/KafkaEventFactory.java
@@ -1,0 +1,17 @@
+package com.lgcms.member.common.kafka.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.lgcms.member.common.kafka.dto.KafkaEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class KafkaEventFactory {
+
+    private final ObjectMapper objectMapper;
+
+    public <T> T convert(KafkaEvent<?> event, Class<T> clazz) {
+        return objectMapper.convertValue(event.getData(), clazz);
+    }
+}

--- a/src/main/java/com/lgcms/member/common/kafka/util/KafkaObjectMapper.java
+++ b/src/main/java/com/lgcms/member/common/kafka/util/KafkaObjectMapper.java
@@ -1,0 +1,14 @@
+package com.lgcms.member.common.kafka.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+public class KafkaObjectMapper {
+    public static ObjectMapper create() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        return mapper;
+    }
+}

--- a/src/main/java/com/lgcms/member/common/kafka/util/serializer/JsonKafkaDeserializer.java
+++ b/src/main/java/com/lgcms/member/common/kafka/util/serializer/JsonKafkaDeserializer.java
@@ -1,0 +1,23 @@
+package com.lgcms.member.common.kafka.util.serializer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.lgcms.member.common.kafka.util.KafkaObjectMapper;
+import org.apache.kafka.common.serialization.Deserializer;
+
+public class JsonKafkaDeserializer<T> implements Deserializer<T> {
+    private final ObjectMapper objectMapper = KafkaObjectMapper.create();
+    private final Class<T> targetType;
+
+    public JsonKafkaDeserializer(Class<T> targetType) {
+        this.targetType = targetType;
+    }
+
+    @Override
+    public T deserialize(String topic, byte[] data) {
+        try {
+            return objectMapper.readValue(data, targetType);
+        } catch (Exception e) {
+            throw new RuntimeException("Kafka JSON Deserialize error", e);
+        }
+    }
+}

--- a/src/main/java/com/lgcms/member/common/kafka/util/serializer/JsonKafkaSerializer.java
+++ b/src/main/java/com/lgcms/member/common/kafka/util/serializer/JsonKafkaSerializer.java
@@ -1,0 +1,18 @@
+package com.lgcms.member.common.kafka.util.serializer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.lgcms.member.common.kafka.util.KafkaObjectMapper;
+import org.apache.kafka.common.serialization.Serializer;
+
+public class JsonKafkaSerializer<T> implements Serializer<T> {
+    private final ObjectMapper objectMapper = KafkaObjectMapper.create();
+
+    @Override
+    public byte[] serialize(String topic, T data) {
+        try {
+            return objectMapper.writeValueAsBytes(data);
+        } catch (Exception e) {
+            throw new RuntimeException("Kafka JSON Serialize error", e);
+        }
+    }
+}

--- a/src/main/java/com/lgcms/member/domain/MemberRole.java
+++ b/src/main/java/com/lgcms/member/domain/MemberRole.java
@@ -1,8 +1,15 @@
 package com.lgcms.member.domain;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
 public enum MemberRole {
-    ADMIN,
-    LECTURER,
-    STUDENT,
+    ADMIN("관리자"),
+    LECTURER("강사"),
+    STUDENT("학생"),
     ;
+
+    private final String memberRoleName;
 }

--- a/src/main/java/com/lgcms/member/event/dto/MemberInfoDto.java
+++ b/src/main/java/com/lgcms/member/event/dto/MemberInfoDto.java
@@ -13,4 +13,13 @@ public class MemberInfoDto {
             return new NicknameModified(member.getId());
         }
     }
+
+    public record MemberQuited(
+        Long memberId,
+        String nickname
+    ) {
+        public static MemberQuited toDto(Member member) {
+            return new MemberQuited(member.getId(), member.getNickname());
+        }
+    }
 }

--- a/src/main/java/com/lgcms/member/event/dto/MemberInfoDto.java
+++ b/src/main/java/com/lgcms/member/event/dto/MemberInfoDto.java
@@ -1,0 +1,16 @@
+package com.lgcms.member.event.dto;
+
+import com.lgcms.member.domain.Member;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class MemberInfoDto {
+    public record NicknameModified(
+        Long memberId
+    ) {
+        static public NicknameModified toDto(Member member) {
+            return new NicknameModified(member.getId());
+        }
+    }
+}

--- a/src/main/java/com/lgcms/member/event/dto/NotificationEventDto.java
+++ b/src/main/java/com/lgcms/member/event/dto/NotificationEventDto.java
@@ -1,0 +1,18 @@
+package com.lgcms.member.event.dto;
+
+import com.lgcms.member.domain.Member;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class NotificationEventDto {
+    public record RoleModified(
+        Long memberId,
+        String nickname,
+        String memberRoleName
+    ) {
+        static public RoleModified toDto(Member member) {
+            return new RoleModified(member.getId(), member.getNickname(), member.getRole().getMemberRoleName());
+        }
+    }
+}

--- a/src/main/java/com/lgcms/member/event/producer/MemberInfoEventProducer.java
+++ b/src/main/java/com/lgcms/member/event/producer/MemberInfoEventProducer.java
@@ -1,6 +1,7 @@
 package com.lgcms.member.event.producer;
 
 import com.lgcms.member.common.kafka.dto.KafkaEvent;
+import com.lgcms.member.event.dto.MemberInfoDto.MemberQuited;
 import com.lgcms.member.event.dto.MemberInfoDto.NicknameModified;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -29,6 +30,17 @@ public class MemberInfoEventProducer {
             .eventTime(LocalDateTime.now().toString())
             .eventType(nicknameModifiedType)
             .data(nicknameModified)
+            .build();
+
+        kafkaTemplate.send(memberInfoTopic, kafkaEvent);
+    }
+
+    public void memberQuitedType(MemberQuited memberQuited) {
+        KafkaEvent kafkaEvent = KafkaEvent.builder()
+            .eventId(applicationName + UUID.randomUUID().toString())
+            .eventTime(LocalDateTime.now().toString())
+            .eventType(memberQuitedType)
+            .data(memberQuited)
             .build();
 
         kafkaTemplate.send(memberInfoTopic, kafkaEvent);

--- a/src/main/java/com/lgcms/member/event/producer/MemberInfoEventProducer.java
+++ b/src/main/java/com/lgcms/member/event/producer/MemberInfoEventProducer.java
@@ -19,7 +19,7 @@ public class MemberInfoEventProducer {
     @Value("${spring.application.name}")
     private String applicationName;
     private final String memberInfoTopic = "MEMBER_INFO";
-    private final String nicknameModifiedType = "MEMBER_MODIFIED";
+    private final String nicknameModifiedType = "NICKNAME_MODIFIED";
     private final String memberQuitedType = "MEMBER_QUITED";
 
     private final KafkaTemplate kafkaTemplate;

--- a/src/main/java/com/lgcms/member/event/producer/MemberInfoEventProducer.java
+++ b/src/main/java/com/lgcms/member/event/producer/MemberInfoEventProducer.java
@@ -1,0 +1,36 @@
+package com.lgcms.member.event.producer;
+
+import com.lgcms.member.common.kafka.dto.KafkaEvent;
+import com.lgcms.member.event.dto.MemberInfoDto.NicknameModified;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class MemberInfoEventProducer {
+    @Value("${spring.application.name}")
+    private String applicationName;
+    private final String memberInfoTopic = "MEMBER_INFO";
+    private final String nicknameModifiedType = "MEMBER_MODIFIED";
+    private final String memberQuitedType = "MEMBER_QUITED";
+
+    private final KafkaTemplate kafkaTemplate;
+
+    public void memberModified(NicknameModified nicknameModified) {
+        KafkaEvent kafkaEvent = KafkaEvent.builder()
+            .eventId(applicationName + UUID.randomUUID().toString())
+            .eventTime(LocalDateTime.now().toString())
+            .eventType(nicknameModifiedType)
+            .data(nicknameModified)
+            .build();
+
+        kafkaTemplate.send(memberInfoTopic, kafkaEvent);
+    }
+}

--- a/src/main/java/com/lgcms/member/event/producer/NotificationEventProducer.java
+++ b/src/main/java/com/lgcms/member/event/producer/NotificationEventProducer.java
@@ -1,0 +1,35 @@
+package com.lgcms.member.event.producer;
+
+import com.lgcms.member.common.kafka.dto.KafkaEvent;
+import com.lgcms.member.event.dto.NotificationEventDto.RoleModified;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class NotificationEventProducer {
+    @Value("${spring.application.name}")
+    private String applicationName;
+    private final String notificationTopic = "NOTIFICATION";
+    private final String roleModifiedType = "ROLE_MODIFIED";
+
+    private final KafkaTemplate kafkaTemplate;
+
+    public void roleModified(RoleModified roleModified) {
+        KafkaEvent kafkaEvent = KafkaEvent.builder()
+            .eventId(applicationName + UUID.randomUUID().toString())
+            .eventTime(LocalDateTime.now().toString())
+            .eventType(roleModifiedType)
+            .data(roleModified)
+            .build();
+
+        kafkaTemplate.send(notificationTopic, kafkaEvent);
+    }
+}

--- a/src/main/java/com/lgcms/member/service/MemberService.java
+++ b/src/main/java/com/lgcms/member/service/MemberService.java
@@ -11,7 +11,9 @@ import com.lgcms.member.domain.MemberCategory;
 import com.lgcms.member.domain.SocialMember;
 import com.lgcms.member.event.dto.MemberInfoDto.MemberQuited;
 import com.lgcms.member.event.dto.MemberInfoDto.NicknameModified;
+import com.lgcms.member.event.dto.NotificationEventDto;
 import com.lgcms.member.event.producer.MemberInfoEventProducer;
+import com.lgcms.member.event.producer.NotificationEventProducer;
 import com.lgcms.member.repository.CategoryRedisRepository;
 import com.lgcms.member.repository.MemberRepository;
 import com.lgcms.member.repository.SocialMemberRepository;
@@ -34,6 +36,7 @@ public class MemberService {
     private final SocialMemberRepository socialMemberRepository;
     private final CategoryRedisRepository categoryRedisRepository;
     private final MemberInfoEventProducer memberInfoEventProducer;
+    private final NotificationEventProducer notificationEventProducer;
 
     @Transactional
     public SignupResponse signup(SignupRequest request) {
@@ -113,7 +116,9 @@ public class MemberService {
     public List<MemberInfoResponse> confirmLecturer(List<Long> memberIds) {
         List<Member> lecturerDesirers = memberRepository.findAllById(memberIds);
         lecturerDesirers.forEach(Member::changeToLecturer);
-        //TODO 강사로 변경된 사람엑게 알림 발송 로직
+        lecturerDesirers.forEach(lecturerDesirer -> {
+            notificationEventProducer.roleModified(NotificationEventDto.RoleModified.toDto(lecturerDesirer));
+        });
         return lecturerDesirers.stream().map(MemberInfoResponse::toDto).toList();
     }
 }

--- a/src/main/java/com/lgcms/member/service/MemberService.java
+++ b/src/main/java/com/lgcms/member/service/MemberService.java
@@ -9,6 +9,7 @@ import com.lgcms.member.domain.Category;
 import com.lgcms.member.domain.Member;
 import com.lgcms.member.domain.MemberCategory;
 import com.lgcms.member.domain.SocialMember;
+import com.lgcms.member.event.dto.MemberInfoDto.MemberQuited;
 import com.lgcms.member.event.dto.MemberInfoDto.NicknameModified;
 import com.lgcms.member.event.producer.MemberInfoEventProducer;
 import com.lgcms.member.repository.CategoryRedisRepository;
@@ -87,6 +88,7 @@ public class MemberService {
             .orElseThrow(() -> new BaseException(NO_MEMBER_PRESENT));
         socialMemberRepository.deleteSocialMemberByMember(member);
         memberRepository.delete(member);
+        memberInfoEventProducer.memberQuitedType(MemberQuited.toDto(member));
         return true;
     }
 

--- a/src/main/java/com/lgcms/member/service/MemberService.java
+++ b/src/main/java/com/lgcms/member/service/MemberService.java
@@ -9,6 +9,8 @@ import com.lgcms.member.domain.Category;
 import com.lgcms.member.domain.Member;
 import com.lgcms.member.domain.MemberCategory;
 import com.lgcms.member.domain.SocialMember;
+import com.lgcms.member.event.dto.MemberInfoDto.NicknameModified;
+import com.lgcms.member.event.producer.MemberInfoEventProducer;
 import com.lgcms.member.repository.CategoryRedisRepository;
 import com.lgcms.member.repository.MemberRepository;
 import com.lgcms.member.repository.SocialMemberRepository;
@@ -30,6 +32,7 @@ public class MemberService {
     private final MemberRepository memberRepository;
     private final SocialMemberRepository socialMemberRepository;
     private final CategoryRedisRepository categoryRedisRepository;
+    private final MemberInfoEventProducer memberInfoEventProducer;
 
     @Transactional
     public SignupResponse signup(SignupRequest request) {
@@ -60,8 +63,10 @@ public class MemberService {
         if (nickname != null) {
             if (checkUsedNickname(memberId, nickname))
                 throw new BaseException(DUPLICATE_NICKNAME);
-            else
+            else {
                 member.setNickname(nickname);
+                memberInfoEventProducer.memberModified(NicknameModified.toDto(member));
+            }
         }
         member.changeDesireLecturer(desireLecturer);
         return MemberInfoResponse.toDto(member);

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -1,4 +1,6 @@
 spring:
+  application:
+    name: backend-member
   datasource:
     url: jdbc:postgresql://localhost:38121/member
     username: lgcms
@@ -8,7 +10,7 @@ spring:
     show-sql: false
     database: postgresql
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true
@@ -17,5 +19,28 @@ spring:
       host: localhost
       port: 38122
       database: 15
+
+  kafka:
+    bootstrap-servers: localhost:38123
+
+    listener:
+      ack-mode: manual_immediate
+
+    consumer:
+      group-id: ${spring.application.name}
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      enable-auto-commit: false
+      auto-offset-reset: latest
+      max-poll-records: 10
+      properties:
+        spring.json.trusted.packages: "*"
+        spring.json.use.type.headers: false
+
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      properties:
+        spring.json.add.type.headers: false
 server:
   port: 38109

--- a/src/main/resources/application-test.yaml
+++ b/src/main/resources/application-test.yaml
@@ -1,4 +1,6 @@
 spring:
+  application:
+    name: backend-member
   datasource:
     url: jdbc:postgresql://localhost:5432/member
     username: lgcms
@@ -17,5 +19,28 @@ spring:
       host: localhost
       port: 6379
       database: 15
+
+  kafka:
+    bootstrap-servers: localhost:9092
+
+    listener:
+      ack-mode: manual_immediate
+
+    consumer:
+      group-id: ${spring.application.name}
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      enable-auto-commit: false
+      auto-offset-reset: latest
+      max-poll-records: 10
+      properties:
+        spring.json.trusted.packages: "*"
+        spring.json.use.type.headers: false
+
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+      properties:
+        spring.json.add.type.headers: false
 server:
   port: 8080


### PR DESCRIPTION
## 작업 내용
    - 회원 닉네임 변경 이벤트 발행
    - 회원 탈퇴 이벤트 발행
    - 회원 권한 변경 이벤트 발행
## 회고, 느낀점 (옵션)
    - 회원가입 축하 메시지는 크게 필요없을거 같아서 제외하고 진행했습니다.